### PR TITLE
Don't require perl 5.14

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,7 +28,7 @@ location = root
 [PkgVersion]
 [PodWeaver]
 [Prereqs]
-perl = 5.014
+perl = 5.010
 Moo = 1.000008
 XML::Simple = 2.20
 IO::Socket::SSL = 1.83

--- a/lib/Net/EC2/Tiny.pm
+++ b/lib/Net/EC2/Tiny.pm
@@ -1,6 +1,6 @@
 package Net::EC2::Tiny;
 
-use 5.014;
+use v5.10;
 
 use POSIX qw(strftime);
 use Digest::SHA qw(hmac_sha256);


### PR DESCRIPTION
...as it isn't needed, and makes using this package difficult on older, but
still supported, systems.
