### PR TITLE
make sure keys are sorted correctly before signing

### DIFF
--- a/lib/Net/EC2/Tiny.pm
+++ b/lib/Net/EC2/Tiny.pm
@@ -161,7 +161,8 @@ sub _sign {
     $sign_this .= "/\n";
 
 
-    $sign_this .= $self->ua->www_form_urlencode(\%sign_hash);
+    $sign_this .= $self->ua->www_form_urlencode( [ map { $_ => $sign_hash{$_} } sort { $a cmp $b } keys %sign_hash ] );
+
 
     warn "QUERY TO SIGN: $sign_this" if $self->debug;
     my $encoded = encode_base64(hmac_sha256($sign_this, $self->AWSSecretKey), '');


### PR DESCRIPTION
This is an important part, since otherwise signature on amazon side is not the same as ours. For example we want this:

```
Region.1=foo&Region.2=foo ... Region.10=foo
```

Instead of the current behaviour:

```
Region.1=foo&Region.10&Region.2=foo ...
```

Notice that Region.10 comes before Region.2
